### PR TITLE
Do not use a singleton stats emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,8 @@ StatsEmitter.prototype._attach = function (listener) {
     this.on('stats', listener);
 };
 
-var statsEmitter = new StatsEmitter();
-
 var requestStats = function (req, res, onStats) {
+  var statsEmitter = new StatsEmitter();
   if (req instanceof http.Server)
     statsEmitter._server(req, res);
   else if (req instanceof http.IncomingMessage)
@@ -61,6 +60,7 @@ var requestStats = function (req, res, onStats) {
 };
 
 requestStats.middleware = function (onStats) {
+  var statsEmitter = new StatsEmitter();
   statsEmitter._attach(onStats);
   return function (req, res, next) {
     statsEmitter._request(req, res);


### PR DESCRIPTION
This should fix a memory leak where the single stats emitter would never clean up its listeners
