### PR TITLE
Do not publish test file

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
   "coordinates": [
     55.6811129,
     12.564524
+  ],
+  "files": [
+    "lib",
+    "index.js"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/watson/request-stats/issues/10

`LICENSE`, `package.json` and `README.md` are published by default according to [this page](https://docs.npmjs.com/files/package.json#files). They were included in the tarball created with `npm pack` when I tested locally.